### PR TITLE
fix(golangci-lint): use top level go mod dir as workdir when it is no…

### DIFF
--- a/internal/linters/go/golangci_lint/golangci_lint_test.go
+++ b/internal/linters/go/golangci_lint/golangci_lint_test.go
@@ -231,7 +231,7 @@ func TestArgs(t *testing.T) {
 	}
 }
 
-func TestConfigApply(t *testing.T) {
+func TestGolangciConfigApply(t *testing.T) {
 	tcs := []struct {
 		id         string
 		input      linters.Agent
@@ -292,7 +292,7 @@ func TestConfigApply(t *testing.T) {
 				}
 			}
 
-			got := configApply(xlog.New("ut"), tc.input)
+			got := golangciConfigApply(xlog.New("ut"), tc.input)
 			if !strings.HasSuffix(got, tc.wantSuffix) {
 				t.Errorf("configApply() = %v, want with suffix %v", got, tc.wantSuffix)
 			}


### PR DESCRIPTION
…t specificed